### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-3d-pack"
+description = ""
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["# base", "cmake", "ninja", "# computational libraries", "numpy", "einops", "scipy", "kornia", "opencv-python", "pillow", "roma", "nerfacc>=0.5.3", "PyMCubes", "scikit-learn", "# for use ML models", "diffusers>=0.26.1", "transformers>=4.36.2", "safetensors", "open_clip_torch", "# for training differentiable tensors", "pytorch_msssim", "# for process images & videos", "imageio", "imageio-ffmpeg", "matplotlib", "# for dmtet and mesh import & export", "trimesh", "plyfile", "pygltflib", "xatlas", "pymeshlab", "# configs & extra", "torchtyping", "tqdm", "jaxtyping", "packaging", "OmegaConf", "pyhocon"]
+
+[project.urls]
+Repository = "https://github.com/MrForExample/ComfyUI-3D-Pack"
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-3D-Pack"
+Icon = ""
+Models = [{location = "/checkpoints/model.safetensor", model_url = "https://example.com/model.zip"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-3d-pack"
-description = ""
+description = "An extensive node suite that enables ComfyUI to process 3D inputs (Mesh & UV Texture, etc) using cutting edge algorithms (3DGS, NeRF, etc.)\nNOTE: Pre-built python wheels can be download from [a/https://github.com/remsky/ComfyUI3D-Assorted-Wheels](https://github.com/remsky/ComfyUI3D-Assorted-Wheels)"
 version = "1.0.0"
 license = "LICENSE"
 dependencies = ["# base", "cmake", "ninja", "# computational libraries", "numpy", "einops", "scipy", "kornia", "opencv-python", "pillow", "roma", "nerfacc>=0.5.3", "PyMCubes", "scikit-learn", "# for use ML models", "diffusers>=0.26.1", "transformers>=4.36.2", "safetensors", "open_clip_torch", "# for training differentiable tensors", "pytorch_msssim", "# for process images & videos", "imageio", "imageio-ffmpeg", "matplotlib", "# for dmtet and mesh import & export", "trimesh", "plyfile", "pygltflib", "xatlas", "pymeshlab", "# configs & extra", "torchtyping", "tqdm", "jaxtyping", "packaging", "OmegaConf", "pyhocon"]
@@ -12,4 +12,3 @@ Repository = "https://github.com/MrForExample/ComfyUI-3D-Pack"
 PublisherId = ""
 DisplayName = "ComfyUI-3D-Pack"
 Icon = ""
-Models = [{location = "/checkpoints/model.safetensor", model_url = "https://example.com/model.zip"}]


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!