### PR TITLE
Update shared_utils/common_utils.py to allow %H in parse_file_name

### DIFF
--- a/shared_utils/common_utils.py
+++ b/shared_utils/common_utils.py
@@ -104,7 +104,7 @@ def parse_save_filename(save_path, output_directory, supported_extensions, class
         
         # replace time date format to current time
         now = datetime.now() # current date and time
-        all_date_format = ["%Y", "%m", "%d", "%M", "%S", "%f"]
+        all_date_format = ["%Y", "%m", "%d", "%H", "%M", "%S", "%f"]
         for date_format in all_date_format:
             if date_format in filename:
                 filename = filename.replace(date_format, now.strftime(date_format))


### PR DESCRIPTION
this fix allows filenames in comfy to include %H, the hour of creation of the object.