### PR TITLE
Update PyProject Toml - License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "comfyui-3d-pack"
 description = "Make ComfyUI generates 3D assets as good & convenient as it generates image/video!"
 version = "0.1.0"
-license = "LICENSE"
+license = { file = "LICENSE" }
 dependencies = ["cmake", "ninja", "PyGithub", "requests", "numpy", "einops", "scipy", "kornia", "opencv-python", "pillow", "roma", "nerfacc>=0.5.3", "PyMCubes", "diffusers>=0.26.1", "transformers>=4.36.2", "safetensors", "open_clip_torch", "torchmetrics", "pytorch_msssim", "pytorch-lightning", "imageio", "imageio-ffmpeg", "matplotlib", "trimesh", "plyfile", "pygltflib", "xatlas", "pymeshlab", "torchtyping", "tqdm", "jaxtyping", "packaging", "OmegaConf", "pyhocon"]
 
 [project.urls]


### PR DESCRIPTION
Hey! HaoHao from [comfy.org](https://comfy.org/) again 😊.

As a heads up, the `license` field is **optional** but in the case that it is filled out, the license file should be referenced either by the file path or by the name of the license.
- `license = { file = "LICENSE" }` ✅
- `license = {text = "MIT License"}` ✅
- `license = "LICENSE"` ❌
- `license = "MIT LICENSE"` ❌

This was brought up in our discord and so we're creating a small PR to update that optional field. For more info check out toml file [standards](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) or our [docs](https://docs.comfy.org/registry/specifications#license) page!