### PR TITLE
fix Rotate_Normal_Maps_Horizontally node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -559,10 +559,11 @@ class Rotate_Normal_Maps_Horizontally:
     CATEGORY = "Comfy3D/Preprocessor"
     
     def make_image_grid(self, normal_maps, normal_masks, clockwise):
+        rotate_direction = 1 if clockwise is True else -1
         if normal_maps.shape[0] > 1:
             from Unique3D.scripts.utils import rotate_normals_torch
             pil_image_list = torch_imgs_to_pils(normal_maps, normal_masks)
-            pil_image_list = rotate_normals_torch(pil_image_list, return_types='pil', rotate_direction=int(clockwise))
+            pil_image_list = rotate_normals_torch(pil_image_list, return_types='pil', rotate_direction=rotate_direction)
             normal_maps = pils_to_torch_imgs(pil_image_list, normal_maps.dtype, normal_maps.device)
         return (normal_maps,)
     


### PR DESCRIPTION
The function [rotate_normals_torch](https://github.com/MrForExample/ComfyUI-3D-Pack/blob/c1718943d8e13844332c346285685681fdba3070/Gen_3D_Modules/Unique3D/scripts/utils.py#L154) requires a `rotate_direction` which should be either 1 or -1, but in the implementation of the node it is `int(clockwise: bool)` which is either 0 or 1, so if `clockwise` is False all angles would be zero, see [here](https://github.com/MrForExample/ComfyUI-3D-Pack/blob/c1718943d8e13844332c346285685681fdba3070/Gen_3D_Modules/Unique3D/scripts/utils.py#L159). This simple fix alleviates the issue.