### PR TITLE
fix outdated nodes in example workflow

### DIFF
--- a/_Example_Workflows/CharacterGen/CharacterGen_InstantMesh.json
+++ b/_Example_Workflows/CharacterGen/CharacterGen_InstantMesh.json
@@ -79,7 +79,7 @@
     },
     {
       "id": 32,
-      "type": "IMG_padder",
+      "type": "Eden_IMG_padder",
       "pos": [
         210,
         440
@@ -110,7 +110,7 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "IMG_padder"
+        "Node name for S&R": "Eden_IMG_padder"
       },
       "widgets_values": [
         0.25,
@@ -317,7 +317,7 @@
     },
     {
       "id": 33,
-      "type": "IMG_padder",
+      "type": "Eden_IMG_padder",
       "pos": [
         570,
         440
@@ -348,7 +348,7 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "IMG_padder"
+        "Node name for S&R": "Eden_IMG_padder"
       },
       "widgets_values": [
         0.2,

--- a/_Example_Workflows/CharacterGen/CharacterGen_to_Unique3D.json
+++ b/_Example_Workflows/CharacterGen/CharacterGen_to_Unique3D.json
@@ -738,7 +738,7 @@
     },
     {
       "id": 350,
-      "type": "IMG_padder",
+      "type": "Eden_IMG_padder",
       "pos": [
         -329.80954879404095,
         -427.3873149879231
@@ -769,7 +769,7 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "IMG_padder"
+        "Node name for S&R": "Eden_IMG_padder"
       },
       "widgets_values": [
         0.25,
@@ -778,7 +778,7 @@
     },
     {
       "id": 351,
-      "type": "IMG_padder",
+      "type": "Eden_IMG_padder",
       "pos": [
         30.190451205959107,
         -427.3873149879231
@@ -809,7 +809,7 @@
         }
       ],
       "properties": {
-        "Node name for S&R": "IMG_padder"
+        "Node name for S&R": "Eden_IMG_padder"
       },
       "widgets_values": [
         0.2,


### PR DESCRIPTION
The `IMG_padder` is renamed to `Eden_IMG_padder` in [eden_comfy_pipelines](https://github.com/edenartlab/eden_comfy_pipelines).
And ComfyUI-Manager can't recognize what the old `IMG_padder` is.

This simple fix did the update with minimum changes.