### PR TITLE
Remove images to avoid git lfs "This repository is over its data quota"

### DIFF
--- a/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/arch.jpg
+++ b/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/arch.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:409049cd3ba0c477d4ef85e82b03fb7d642cecabe8a44c5824818a435ed166d1
-size 1177273

--- a/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/e2e-1.gif
+++ b/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/e2e-1.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c582fdb3f6560b70418d1166a8024640a49f162b6969e03dc1a54ad196a837c
-size 8786876

--- a/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/e2e-2.gif
+++ b/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/e2e-2.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:074ecb05f60c224f79e35e294ce847a7b77511c355fbcd57d3e82aa253eeb320
-size 9021984

--- a/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/system.jpg
+++ b/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/system.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b38a34f393ff023b56c18a0fffec186018a4c5ef8f275250698c27123035474
-size 1569660

--- a/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/teaser.jpg
+++ b/Checkpoints/Diffusers/tencent/Hunyuan3D-2/assets/images/teaser.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9deac73e728652dfa5e2b73833401dcf659cce9d15a9150a52d8aac62c91e4c9
-size 1867475


### PR DESCRIPTION
These images are assets for documents, it's safe to remove them.