### PR TITLE
Change node id name.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "comfyui-3d-pack"
+name = "ComfyUI-3D-Pack"
 description = "Make ComfyUI generates 3D assets as good & convenient as it generates image/video!"
 version = "0.1.3"
 license = { file = "LICENSE" }


### PR DESCRIPTION
We realized that ComfyUI-3D-Pack needs to have the original casing in the node id name. ComfyUI-Manager currently installs all nodes using the node id.

eg. Currently, this custom node installed from the registry will be `custom_nodes/comfyui-3d-pack`. 

This causes issues when importing files using the `/extensions` backend api: eg.`/extensions/ComfyUI-3D-Pack/style/coloris.css`

After this PR is merged, we can help you rename the existing node versions in the registry api database with the new node name. All future node versions published will have this updated node-id.

**Impact to current users**
This only applies for users that have installed this node using the registry: They will need to reinstall the node from Manager. For users that have installed this using git, or the "nightly" version, there should be no action necessary.