### PR TITLE
fix wsl2 eglInitialize() failed

### DIFF
--- a/Gen_3D_Modules/Unique3D/mesh_reconstruction/render.py
+++ b/Gen_3D_Modules/Unique3D/mesh_reconstruction/render.py
@@ -12,11 +12,11 @@ def _warmup(glctx, device=None):
     tri = tensor([[0, 1, 2]], dtype=torch.int32)
     dr.rasterize(glctx, pos, tri, resolution=[256, 256])
 
-glctx = dr.RasterizeGLContext(output_db=False, device="cuda")
+glctx = dr.RasterizeCudaContext(device="cuda")
 
 class NormalsRenderer:
     
-    _glctx:dr.RasterizeGLContext = None
+    _glctx:dr.RasterizeCudaContext = None
     
     def __init__(
             self,

--- a/Gen_3D_Modules/Unique3D/scripts/project_mesh.py
+++ b/Gen_3D_Modules/Unique3D/scripts/project_mesh.py
@@ -68,7 +68,7 @@ def _warmup(glctx, device=None):
 
 class Pix2FacesRenderer:
     def __init__(self, device="cuda"):
-        self._glctx = dr.RasterizeGLContext(output_db=False, device=device)
+        self._glctx = dr.RasterizeCudaContext(device=device)
         self.device = device
         _warmup(self._glctx, device)
 

--- a/MVs_Algorithms/FlexiCubes/flexicubes_renderer.py
+++ b/MVs_Algorithms/FlexiCubes/flexicubes_renderer.py
@@ -43,7 +43,7 @@ class FlexiCubesRenderer:
         '''
         v_pos_clip = util.xfm_points(mesh.vertices.unsqueeze(0), mvp)  # Rotate it to camera coordinates
         rast, db = dr.rasterize(
-            dr.RasterizeGLContext(), v_pos_clip, mesh.faces.int(), iter_res)
+            dr.RasterizeCudaContext(), v_pos_clip, mesh.faces.int(), iter_res)
 
         alpha_index = rast[..., -1:] > 0
         inv_alpha_index = rast[..., -1:] <= 0

--- a/nodes.py
+++ b/nodes.py
@@ -987,7 +987,7 @@ class Mesh_Orbit_Renderer:
                 "render_background_color_r": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
                 "render_background_color_g": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
                 "render_background_color_b": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
-                "force_cuda_rasterize": ("BOOLEAN", {"default": False},),
+                "force_cuda_rasterize": ("BOOLEAN", {"default": True},),
             },
             
             "optional": {
@@ -1302,7 +1302,7 @@ class Fitting_Mesh_With_Multiview_Images:
                 "ms_ssim_loss_weight": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "remesh_after_n_iteration": ("INT", {"default": 512, "min": 128, "max": 100000}),
                 "invert_background_probability": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.1}),
-                "force_cuda_rasterize": ("BOOLEAN", {"default": False},),
+                "force_cuda_rasterize": ("BOOLEAN", {"default": True},),
             },
         }
 


### PR DESCRIPTION
I recently tried to develop in wsl2, but no matter what, I couldn't get it to work, `eglInitialize() failed`

So I searched for the cause of the error, and found that it was caused by nvdiffrast, so I checked [nvidia documentation](https://docs.nvidia.com/cuda/wsl-user-guide/index.html), and found that OpenGL-CUDA Interop is not yet supported.

So I tried to change RasterizeGLContext to RasterizeCudaContext, and it worked fine!

I think RasterizeCudaContext should be the default behavior, because it seems to be more compatible.