### PR TITLE
Fix broken model path for TRELLIS weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Your ComfyUI Root Directory\python_embeded\python.exe install.py
 
 - **TRELLIS**: [microsoft/TRELLIS](https://github.com/microsoft/TRELLIS)
   - Single image to 3D Mesh with RGB texture
-  - Model weights: https://huggingface.co/JeffreyXiang/TRELLIS-image-large
+  - Model weights: https://huggingface.co/jetx/TRELLIS-image-large
 
   <video controls autoplay loop src="https://github.com/user-attachments/assets/f569c561-23ea-471f-a9d3-f2e6d1803e00"></video>
 

--- a/_Example_Workflows/Trellis_Image_to_Mesh.json
+++ b/_Example_Workflows/Trellis_Image_to_Mesh.json
@@ -232,7 +232,7 @@
         "Node name for S&R": "[Comfy3D] Load Trellis Structured 3D Latents Models"
       },
       "widgets_values": [
-        "JeffreyXiang/TRELLIS-image-large"
+        "jetx/TRELLIS-image-large"
       ]
     }
   ],

--- a/nodes.py
+++ b/nodes.py
@@ -4020,7 +4020,7 @@ class Hunyuan3D_V2_Paint_Model:
         return (mesh,)
     
 class Load_Trellis_Structured_3D_Latents_Models:
-    default_repo_id = "JeffreyXiang/TRELLIS-image-large"
+    default_repo_id = "jetx/TRELLIS-image-large"
 
     @classmethod
     def INPUT_TYPES(cls):


### PR DESCRIPTION
The old model URL is no longer available:
https://huggingface.co/JeffreyXiang/TRELLIS-image-large

This issue is also mentioned in the official repository:
https://github.com/microsoft/TRELLIS/issues/263
https://github.com/microsoft/TRELLIS/issues/264

Updated to:
https://huggingface.co/jetx/trellis-image-large (temporary path, according to discussion it is likely to be moved to the official Microsoft HuggingFace account later)