### PR TITLE
Fix: TypeError: Hunyuan3DPaintPipeline.from_pretrained() got an unexpected keyword argument 'torch_dtype'

### DIFF
--- a/Gen_3D_Modules/Hunyuan3D_V2/hy3dgen/texgen/pipelines.py
+++ b/Gen_3D_Modules/Hunyuan3D_V2/hy3dgen/texgen/pipelines.py
@@ -52,7 +52,7 @@ class Hunyuan3DTexGenConfig:
 
 class Hunyuan3DPaintPipeline:
     @classmethod
-    def from_pretrained(cls, model_path, subfolder='hunyuan3d-paint-v2-0-turbo'):
+    def from_pretrained(cls, model_path, subfolder='hunyuan3d-paint-v2-0-turbo', **kwargs):
         delight_model_path   = os.path.join(model_path, 'hunyuan3d-delight-v2-0')
         multiview_model_path = os.path.join(model_path, subfolder)
 


### PR DESCRIPTION
Fix #498